### PR TITLE
mark `ActualClassLoader#getTransformers()` as non-static

### DIFF
--- a/src/main/java/top/outlands/foundation/boot/ActualClassLoader.java
+++ b/src/main/java/top/outlands/foundation/boot/ActualClassLoader.java
@@ -355,7 +355,7 @@ public class ActualClassLoader extends URLClassLoader {
         return basicClass;
     }
 
-    public static List<IClassTransformer> getTransformers() {
+    public List<IClassTransformer> getTransformers() {
         return transformers;
     }
 


### PR DESCRIPTION
原以为有 #2 在前，kappa肯定是知道怎么做的，没想到 `getTransformers()` 还是写成了 static method:

```
java.lang.IncompatibleClassChangeError: Expecting non-static method 'java.util.List top.outlands.foundation.boot.ActualClassLoader.getTransformers()'
    at net.minecraftforge.fml.common.Loader.handler$zza000$unknown_owner$beforeConstructingMods(Loader.java:1132)
    at net.minecraftforge.fml.common.Loader.loadMods(Loader.java:599)
    at net.minecraftforge.fml.client.FMLClientHandler.beginMinecraftLoading(FMLClientHandler.java:232)
    at net.minecraft.client.Minecraft.init(Minecraft.java:467)
...
```

![图片](https://github.com/user-attachments/assets/9634efd3-6412-4b33-9133-69818f7fbc99)
