### PR TITLE
One more `Method` -> `MethodHandle` replacement

### DIFF
--- a/src/main/java/top/outlands/foundation/boot/Foundation.java
+++ b/src/main/java/top/outlands/foundation/boot/Foundation.java
@@ -6,7 +6,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import zone.rong.imaginebreaker.ImagineBreaker;
 
-import java.lang.reflect.Method;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -37,8 +38,9 @@ public class Foundation {
                 LOGGER.info("System ClassLoader is LCL");
             }
             Object handler = Class.forName("top.outlands.foundation.LaunchHandler", true, Launch.classLoader).getConstructor().newInstance();
-            Method launch = handler.getClass().getMethod("launch", String[].class);
-            launch.invoke(handler, (Object) args);
+            MethodHandles.lookup()
+                .findVirtual(handler.getClass(), "launch", MethodType.methodType(void.class, String[].class))
+                .invoke(handler, (Object) args);
         } catch (Throwable e) {
             e.printStackTrace();
             System.exit(1);


### PR DESCRIPTION
刚刚检查崩溃报告的时候意外发现Foundation里还有一处可以消去的`Method.invoke(...)`

```
    at net.minecraft.client.main.Main.main(SourceFile:123)
->  at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
->  at java.lang.reflect.Method.invoke(Method.java:580)
    at top.outlands.foundation.LaunchHandler.launch(LaunchHandler.java:121)
->  at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
->  at java.lang.reflect.Method.invoke(Method.java:580)
    at top.outlands.foundation.boot.Foundation.main(Foundation.java:41)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke(Method.java:580)
    at com.cleanroommc.relauncher.wrapper.RelaunchMainWrapper.main(RelaunchMainWrapper.java:15)
```