### PR TITLE
Cache `JarFile#getManifest()` result in `ActualClassLoader#findClass`

### DIFF
--- a/src/main/java/top/outlands/foundation/boot/ActualClassLoader.java
+++ b/src/main/java/top/outlands/foundation/boot/ActualClassLoader.java
@@ -62,6 +62,8 @@ public class ActualClassLoader extends URLClassLoader {
     static TransformerHolder transformerHolder = new TransformerHolder();
     private Map<Package, Manifest> packageManifests = null;
     private static Manifest EMPTY = new Manifest();
+    // URLJarFile.getManifest() deep-clones every call; cache the result per jar.
+    private final Map<String, Manifest> manifestCache = new ConcurrentHashMap<>();
 
 
     public ActualClassLoader(URL[] sources) {
@@ -191,9 +193,9 @@ public class ActualClassLoader extends URLClassLoader {
             if (lastDot > -1 && !untransformedName.startsWith("net.minecraft.")) {
                 if (urlConnection instanceof JarURLConnection jarURLConnection) {
                     final JarFile jarFile = jarURLConnection.getJarFile();
+                    Manifest manifest = jarFile == null ? null : getCachedManifest(jarFile);
 
-                    if (jarFile != null && jarFile.getManifest() != null) {
-                        Manifest manifest = jarFile.getManifest();
+                    if (manifest != null) {
                         final JarEntry entry = jarFile.getJarEntry(fileName);
 
                         Package pkg = getDefinedPackage(packageName);
@@ -320,6 +322,18 @@ public class ActualClassLoader extends URLClassLoader {
             }
         }
         return "true".equalsIgnoreCase(sealed);
+    }
+
+    private Manifest getCachedManifest(final JarFile jarFile) throws IOException {
+        Manifest cached = manifestCache.get(jarFile.getName());
+        if (cached != null) {
+            return cached;
+        }
+        Manifest fresh = jarFile.getManifest();
+        if (fresh != null) {
+            manifestCache.put(jarFile.getName(), fresh);
+        }
+        return fresh;
     }
 
     protected URLConnection findCodeSourceConnectionFor(final String name) {


### PR DESCRIPTION
`findClass` calls `jarFile.getManifest()` twice per class load (once for the
null-check, once to bind `manifest`). `URLJarFile.getManifest()` returns a
deep clone of the cached manifest on every call (fresh `Manifest`,
`Attributes`, `LinkedHashMap`).

Cache the result in a small per-jar `ConcurrentHashMap` on the class loader
so the clone only happens once per jar instead of twice per class load.

Downstream consumers in this method (`isSealed`, `URLClassLoader#definePackage`)
only read from the Manifest, so sharing one instance per jar is safe.
`IOException` from `getManifest()` still propagates to the outer
`catch (Throwable)` in `findClass`.

Measured on a 412-mod 1.12.2 Cleanroom pack against published `0.17.1`
(`findClass` hot path is verbatim the same on current `main`):
`URLJarFile.getManifest` inclusive Client-thread time drops from ~24 s to
near-zero; warm startup ~218 s → ~200 s (n=3, -8 %).