### PR TITLE
Preserve failure causes for invalid classes

### DIFF
--- a/src/main/java/top/outlands/foundation/boot/ActualClassLoader.java
+++ b/src/main/java/top/outlands/foundation/boot/ActualClassLoader.java
@@ -22,6 +22,7 @@ import java.security.CodeSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -47,7 +48,8 @@ public class ActualClassLoader extends URLClassLoader {
     public static final PrefixTrie<Boolean> classLoaderExceptions = new PrefixTrie<>();
     public static final PrefixTrie<Boolean> transformerExceptions = new PrefixTrie<>();
     private final Map<String, Class<?>> cachedClasses = new ConcurrentHashMap<>();
-    private final Map<String, Throwable> invalidClasses = new ConcurrentHashMap<>(1024);
+    private final Map<String, Throwable> invalidClassesMap = new ConcurrentHashMap<>(1024);
+    private final Set<String> invalidClasses = Collections.unmodifiableSet(invalidClassesMap.keySet());
 
     private final Map<String, byte[]> resourceCache = new ConcurrentHashMap<>(1024);
     private final Set<String> negativeResourceCache = ConcurrentHashMap.newKeySet();
@@ -177,7 +179,7 @@ public class ActualClassLoader extends URLClassLoader {
 
     @Override
     public Class<?> findClass(final String name) throws ClassNotFoundException {
-        Throwable invalidCause = invalidClasses.get(name);
+        Throwable invalidCause = invalidClassesMap.get(name);
         if (invalidCause != null) {
             throw new ClassNotFoundException(
                 "Found " + name + " in invalid classes. Original failure:",
@@ -283,7 +285,7 @@ public class ActualClassLoader extends URLClassLoader {
             }
             return clazz;
         } catch (Throwable e) {
-            invalidClasses.put(name, e);
+            invalidClassesMap.put(name, e);
             if (VERBOSE) {
                 LOGGER.debug("Failed to load class {}, caused by {}", name, e);
                 Arrays.stream(e.getStackTrace()).forEach(LOGGER::debug);
@@ -538,7 +540,7 @@ public class ActualClassLoader extends URLClassLoader {
     }
 
     public Set<String> getInvalidClasses() {
-        return invalidClasses.keySet();
+        return invalidClassesMap.keySet();
     }
 
     /**

--- a/src/main/java/top/outlands/foundation/boot/ActualClassLoader.java
+++ b/src/main/java/top/outlands/foundation/boot/ActualClassLoader.java
@@ -49,7 +49,7 @@ public class ActualClassLoader extends URLClassLoader {
     public static final PrefixTrie<Boolean> transformerExceptions = new PrefixTrie<>();
     private final Map<String, Class<?>> cachedClasses = new ConcurrentHashMap<>();
     private final Map<String, Throwable> invalidClassesMap = new ConcurrentHashMap<>(1024);
-    private final Set<String> invalidClasses = Collections.unmodifiableSet(invalidClassesMap.keySet());
+    private final Set<String> invalidClasses = new HashSet<>(1024);
 
     private final Map<String, byte[]> resourceCache = new ConcurrentHashMap<>(1024);
     private final Set<String> negativeResourceCache = ConcurrentHashMap.newKeySet();
@@ -286,6 +286,7 @@ public class ActualClassLoader extends URLClassLoader {
             return clazz;
         } catch (Throwable e) {
             invalidClassesMap.put(name, e);
+            invalidClasses.add(name);
             if (VERBOSE) {
                 LOGGER.debug("Failed to load class {}, caused by {}", name, e);
                 Arrays.stream(e.getStackTrace()).forEach(LOGGER::debug);

--- a/src/main/java/top/outlands/foundation/boot/ActualClassLoader.java
+++ b/src/main/java/top/outlands/foundation/boot/ActualClassLoader.java
@@ -47,7 +47,7 @@ public class ActualClassLoader extends URLClassLoader {
     public static final PrefixTrie<Boolean> classLoaderExceptions = new PrefixTrie<>();
     public static final PrefixTrie<Boolean> transformerExceptions = new PrefixTrie<>();
     private final Map<String, Class<?>> cachedClasses = new ConcurrentHashMap<>();
-    private final Set<String> invalidClasses = new HashSet<>(1024);
+    private final Map<String, Throwable> invalidClasses = new ConcurrentHashMap<>(1024);
 
     private final Map<String, byte[]> resourceCache = new ConcurrentHashMap<>(1024);
     private final Set<String> negativeResourceCache = ConcurrentHashMap.newKeySet();
@@ -177,9 +177,14 @@ public class ActualClassLoader extends URLClassLoader {
 
     @Override
     public Class<?> findClass(final String name) throws ClassNotFoundException {
-        if (invalidClasses.contains(name)) {
-            throw new ClassNotFoundException("Found " + name + " in invalid classes.");
+        Throwable invalidCause = invalidClasses.get(name);
+        if (invalidCause != null) {
+            throw new ClassNotFoundException(
+                "Found " + name + " in invalid classes. Original failure:",
+                invalidCause
+            );
         }
+        
         TrieNode<Boolean> node = classLoaderExceptions.getFirstKeyValueNode(name);
         if (node != null && node.getValue()) {
             return parent.loadClass(name);
@@ -278,7 +283,7 @@ public class ActualClassLoader extends URLClassLoader {
             }
             return clazz;
         } catch (Throwable e) {
-            invalidClasses.add(name);
+            invalidClasses.put(name, e);
             if (VERBOSE) {
                 LOGGER.debug("Failed to load class {}, caused by {}", name, e);
                 Arrays.stream(e.getStackTrace()).forEach(LOGGER::debug);
@@ -533,7 +538,7 @@ public class ActualClassLoader extends URLClassLoader {
     }
 
     public Set<String> getInvalidClasses() {
-        return invalidClasses;
+        return invalidClasses.keySet();
     }
 
     /**


### PR DESCRIPTION
## Summary

Preserve the original `Throwable` when a class is added to `invalidClasses`.

Previously, once a class failed to load, only its name was stored. Subsequent attempts to load the same class would only report:

```text
Found <class> in invalid classes.
```

This loses the original exception and makes the actual cause of the class-loading failure difficult to diagnose.

## Changes

* Store the original `Throwable` associated with each invalid class.
* Include the original failure as the cause when an invalid class is loaded again.
* Keep `getInvalidClasses()` returning `Set<String>` for API compatibility.
* Add `getInvalidClassCause(String)` to retrieve the original failure.
* Use `ConcurrentHashMap` for the invalid-class cache.

## Example

Previously:

```text
ClassNotFoundException: Found example.SomeClass in invalid classes.
```

Now:

```text
ClassNotFoundException: Found example.SomeClass in invalid classes. Original failure:
    ...
Caused by: <original exception>
```

This makes repeated class-loading failures considerably easier to diagnose without changing the existing `getInvalidClasses()` API.
